### PR TITLE
fix: correct script name in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Test your setup with a simple example:
 
 ```bash
 # Run the GitHub trending example
-python examples/test_agent.py --task github_trending
+python examples/simple_agent.py --task github_trending
 ```
 
 **Expected output:**


### PR DESCRIPTION
## 📌 Description

### What does this PR do?
Fixes an incorrect script filename in the README documentation.

### Related Issue
Closes #5 

### Changes Made
- Updated `README.md`:
  - Replaced `test_agent.py` with `simple_agent.py` in the GitHub trending example command

### Type of Change
- [x] Bug fix (documentation)

### ✅ Quality Checks
- [x] flake8 passed  
- [x] black passed  
- [x] mypy passed  
- [x] pytest passed  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the README command for the GitHub trending example to use `simple_agent.py` instead of `test_agent.py`.

<sup>Written for commit 7bc7dea38dc66a316948be5583b338fa8998f38c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

